### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) tool that provides DNS querying capabilities. This tool allows you to perform DNS lookups for various record types through a standardized MCP interface.
 
+<a href="https://glama.ai/mcp/servers/@glucn/mcp-dns">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@glucn/mcp-dns/badge" alt="DNS MCP server" />
+</a>
+
 ## Features
 
 - DNS querying for various record types (A, AAAA, MX, TXT, CNAME, NS, etc.)


### PR DESCRIPTION
This PR adds a badge for the [MCP DNS](https://glama.ai/mcp/servers/@glucn/mcp-dns) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@glucn/mcp-dns">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@glucn/mcp-dns/badge" alt="DNS MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.